### PR TITLE
Downgrade go version to 1.13.6 on actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.13.6
 
     - name: Build
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master,dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master,dev ]
 
 jobs:
 
@@ -25,7 +25,7 @@ jobs:
 
     - name: Test
       run: |
-       go mod init
+       go mod init github.com/kxchange/go-emojify
        go get
        go get -v github.com/stretchr/testify/assert
        go test -v ./...


### PR DESCRIPTION
`unquoteCodePoint` not work at go v1.15, so downgrade to go v1.13.6 (my local env using v1.13.6)